### PR TITLE
Fixed multi-monitor screen picking. (Builds not updated; fixes issue #1)

### DIFF
--- a/ScreenDrop/Model/ColorConverter.cs
+++ b/ScreenDrop/Model/ColorConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,21 +10,30 @@ using System.Windows.Media.Imaging;
 
 namespace ScreenDropper.Model
 {
-    //This class gets the color value of the specific pixel in the Bitmap by using it's x and y coordinates
-   public  class ColorConverter
+    // This class gets the color value of the specific pixel in the Bitmap by using its x and y coordinates
+    public class ColorConverter
     {
-        public Color GetColor(BitmapSource bitmap,int x,int y)
+        public Color GetColor(BitmapSource bitmap, int x, int y)
         {
-            List<string> hashCode= new List<string>();
             int stride = bitmap.PixelWidth * (bitmap.Format.BitsPerPixel / 8);
-                    byte[] pixel = new byte[bitmap.PixelHeight];//holds color values of a single pixel
-                    bitmap.CopyPixels(new Int32Rect(x,y,1,1), pixel, stride, 0);//assigns color values of a single pixel to the pixel array
-                    Color singlePixel = new Color();//creates new color objects and assigns the color values found in pixel array to it
-                    singlePixel.B = pixel[0];
-                    singlePixel.G = pixel[1];
-                    singlePixel.R = pixel[2];
-                    singlePixel.A = pixel[3];
-                    return singlePixel;
+            int channelCount = bitmap.Format.Masks.Count(); // 4
+
+            // Make sure we have at least 3 color channels.
+            Debug.Assert(channelCount >= 3);
+
+            byte[] pixel = new byte[channelCount]; // Holds color values of a single pixel.
+
+            bitmap.CopyPixels(new Int32Rect(x, y, 1, 1), pixel, stride, 0); // Assigns color values of a single pixel to the pixel array
+
+            Color singlePixel = new Color(); // Creates a new color object, and assigns the color values found in pixel array to it
+
+            singlePixel.B = pixel[0];
+            singlePixel.G = pixel[1];
+            singlePixel.R = pixel[2];
+
+            singlePixel.A = (channelCount >= 4) ? pixel[3] : (byte)255; // 0;
+
+            return singlePixel;
         }
     }
 }

--- a/ScreenDrop/Model/MouseHook.cs
+++ b/ScreenDrop/Model/MouseHook.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
+//using System.Windows.Forms;
 using System.Threading;
 using System.Diagnostics;
 using System.Windows.Media;
@@ -78,10 +79,22 @@ namespace ScreenDropper.Model
             {
 
                 MSLLHOOKSTRUCT hookStruct = (MSLLHOOKSTRUCT)Marshal.PtrToStructure(lParam, typeof(MSLLHOOKSTRUCT));
-                color = converter.GetColor(screenCapture.CaptureScreen(), hookStruct.pt.x, hookStruct.pt.y);
+
+                int curX = hookStruct.pt.x;
+                int curY = hookStruct.pt.y;
+
+                //var cursorPos = Cursor.Position;
+
+                // This isn't ideal, but it fixes the coordinate system:
+                curX -= (int)SystemParameters.VirtualScreenLeft;
+                curY -= (int)SystemParameters.VirtualScreenTop;
+
+                color = converter.GetColor(screenCapture.CaptureScreen(), curX, curY);
+
                 R = color.R;
                 G = color.G;
                 B = color.B;
+
                 HEX = "#" + color.R.ToString("X2") + color.G.ToString("X2") + color.B.ToString("X2");
             }
 


### PR DESCRIPTION
This should fix issue #1. It's not the best approach, but it works.

Honestly, I don't exactly know why you're using the Windows API directly. Windows Forms already does half of what you're doing, and it's nicer. Not sure about mouse/keyboard button detection, though.

Whatever the case, I also cleaned up the 'ColorConverter' class. Not sure why it's not static, but now it has a debug-assert (Feel free to remove that), and it _should_ check the number of color channels safely. That may still need to be tested, though. This also means you aren't allocating a bunch of bytes for no reason.

Neat little program, though. Not that this isn't a cool hobby project in its own right, but a cool alternative tool to checkout is [ShareX](https://github.com/ShareX/ShareX), which has a [color picker](https://github.com/ShareX/ShareX/issues/446) built in (Didn't actually know that before).
